### PR TITLE
Fix unit tests

### DIFF
--- a/spec/lita/handlers/onewheel_finance_spec.rb
+++ b/spec/lita/handlers/onewheel_finance_spec.rb
@@ -5,53 +5,50 @@ def mock_up(filename)
   allow(RestClient).to receive(:get) { mock }
 end
 
-describe Lita::Handlers::OnewheelFinance, lita_handler: true do
-  #it 'feds' do
-  #
-  #end
+describe Lita::Handlers::OnewheelFinance, lita_handler: true do  
 
   it 'quotes up' do
     mock_up 'worldtradedata-quote-up'
+    Lita.configure do |config|
+      config.handlers.onewheel_finance.handler = 'worldtradedata'
+    end    
     send_command 'quote lulu'
-    expect(replies.last).to include("\u000314NASDAQ - \u0003LULU: \u000302$233.01\u0003")
-    expect(replies.last).to include('(Lululemon Athletica Inc.)')
+    expect(replies.last).to include(" LULU: $233.01 \u000303 $1.34\u0003, \u0003030.58%\u0003")    
+  end
+
+  it 'quotes yahoo' do
+    Lita.configure do |config|
+      config.handlers.onewheel_finance.handler = 'yahoo'
+    end
+    mock_up 'yahoo-quote'
+    send_command 'quote zm'
+    expect(replies.last).to include(" ZM: $179.75 \u000303 $10.66\u0003, \u0003036.3%\u0003")    
   end
 
   it 'quotes down' do
     mock_up 'worldtradedata-quote-down'
+    Lita.configure do |config|
+      config.handlers.onewheel_finance.handler = 'worldtradedata'
+    end   
     send_command 'quote xlp'
-    expect(replies.last).to include("\u000314NYSE - \u0003XLP: \u000302$62.51\u0003")
-    expect(replies.last).to include('↯$-0.47')
-    expect(replies.last).to include('(Consumer Staples Select Sector SPDR Fund)')
+    expect(replies.last).to include("XLP: $62.51 \u000304 $-0.47\u0003, \u000304-0.75%\u0003")    
   end
 
   it 'nasdaq:lulu' do
     mock_up 'worldtradedata-quote-up'
+    Lita.configure do |config|
+      config.handlers.onewheel_finance.handler = 'worldtradedata'
+    end   
     send_command 'q nasdaq:lulu'
-    expect(replies.last).to include("\u000314NASDAQ - \u0003LULU: \u000302$233.01\u0003")
+    expect(replies.last).to include(" LULU: $233.01 \u000303 $1.34\u0003, \u0003030.58%\u0003")
   end
 
   it 'removes $ from ^ reqs' do
     mock_up 'worldtradedata-quote-dji'
+    Lita.configure do |config|
+      config.handlers.onewheel_finance.handler = 'worldtradedata'
+    end   
     send_command 'q ^dji'
-    expect(replies.last).to include("\u000314INDEXDJX - \u0003^DJI: \u00030225766.64\u0003 \u000304 ↯-1190.95\u0003, \u000304-4.42%\u0003 \u000314(Dow Jones Industrial Average)\u0003")
-  end
-
-  #it 'errors' do
-  #  mock_up 'worldtradedata-error'
-  #  send_command 'quote in'
-  #  expect(replies.last).to eq('`in` not found on any stock exchange.')
-  #end
-
-
-  # This doesn't exist
-  #it 'TADAWUL:2222' do
-  #  mock_up 'worldtradedata-TADAWUL-2222.json'
-  #
-  #end
-  #it 'searches with 1 result' do
-  #  mock_up 'worldtradedata-search-1'
-  #  send_command 'quote nike'
-  #  expect(replies.last).to eq('NKE')
-  #end
+    expect(replies.last).to include(" ^DJI: 25766.64 \u000304 -1190.95\u0003, \u000304-4.42%\u0003")
+  end  
 end

--- a/spec/lita/handlers/onewheel_finance_spec.rb
+++ b/spec/lita/handlers/onewheel_finance_spec.rb
@@ -8,46 +8,36 @@ end
 describe Lita::Handlers::OnewheelFinance, lita_handler: true do  
 
   it 'quotes up' do
-    mock_up 'worldtradedata-quote-up'
-    Lita.configure do |config|
-      config.handlers.onewheel_finance.handler = 'worldtradedata'
-    end    
+    mock_up 'worldtradedata-quote-up'    
+    registry.config.handlers.onewheel_finance.handler = 'worldtradedata'    
     send_command 'quote lulu'
     expect(replies.last).to include(" LULU: $233.01 \u000303 $1.34\u0003, \u0003030.58%\u0003")    
   end
 
   it 'quotes yahoo' do
-    Lita.configure do |config|
-      config.handlers.onewheel_finance.handler = 'yahoo'
-    end
     mock_up 'yahoo-quote'
+    registry.config.handlers.onewheel_finance.handler = 'yahoo'    
     send_command 'quote zm'
     expect(replies.last).to include(" ZM: $179.75 \u000303 $10.66\u0003, \u0003036.3%\u0003")    
   end
 
   it 'quotes down' do
     mock_up 'worldtradedata-quote-down'
-    Lita.configure do |config|
-      config.handlers.onewheel_finance.handler = 'worldtradedata'
-    end   
+    registry.config.handlers.onewheel_finance.handler = 'worldtradedata'       
     send_command 'quote xlp'
     expect(replies.last).to include("XLP: $62.51 \u000304 $-0.47\u0003, \u000304-0.75%\u0003")    
   end
 
   it 'nasdaq:lulu' do
     mock_up 'worldtradedata-quote-up'
-    Lita.configure do |config|
-      config.handlers.onewheel_finance.handler = 'worldtradedata'
-    end   
+    registry.config.handlers.onewheel_finance.handler = 'worldtradedata'       
     send_command 'q nasdaq:lulu'
     expect(replies.last).to include(" LULU: $233.01 \u000303 $1.34\u0003, \u0003030.58%\u0003")
   end
 
   it 'removes $ from ^ reqs' do
     mock_up 'worldtradedata-quote-dji'
-    Lita.configure do |config|
-      config.handlers.onewheel_finance.handler = 'worldtradedata'
-    end   
+    registry.config.handlers.onewheel_finance.handler = 'worldtradedata'     
     send_command 'q ^dji'
     expect(replies.last).to include(" ^DJI: 25766.64 \u000304 -1190.95\u0003, \u000304-4.42%\u0003")
   end  


### PR DESCRIPTION
Don't really like having to do this for every test:

    Lita.configure do |config|
      config.handlers.onewheel_finance.handler = 'yahoo'
    end

There must be a better way.